### PR TITLE
Connect Elefant DB to Metabase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY firebird-ssh-tunnel.sh /app/
 RUN ["chmod", "+x", "/app/firebird-ssh-tunnel.sh"]
 
 # Run the SSH tunnel and Metabase
-ENTRYPOINT ["/bin/bash", "-c", "/app/firebird-ssh-tunnel.sh & /app/docker-entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,33 @@
-FROM metabase/metabase:v0.48.8
+# Stage 1: Base image with Alpine to install sshpass
+FROM alpine:latest as builder
+
+# Install dependencies for building
+RUN apk add --no-cache openssh-client sshpass
+
+# Stage 2: Metabase image
+# Using Metabase version 0.47.13 because it is the highest version that currently works with the Firebird plugin
+FROM metabase/metabase:v0.47.13
+
+# Copy SSH tools from builder image
+COPY --from=builder /usr/bin/ssh /usr/bin/ssh
+COPY --from=builder /usr/bin/sshpass /usr/bin/sshpass
 
 COPY docker-entrypoint.sh /app/
 
+# Download the custom Firebird driver for Metabase
+RUN wget -O /app/firebird.metabase-driver.jar https://github.com/evosec/metabase-firebird-driver/releases/download/v1.5.0/firebird.metabase-driver.jar
+
+# Create Metabase plugins directory if it does not exist
+RUN mkdir -p /plugins
+
+# Move the Firebird driver to the plugins directory
+RUN mv /app/firebird.metabase-driver.jar /plugins/
+
 RUN ["chmod", "+x", "/app/docker-entrypoint.sh"]
 
-ENTRYPOINT [ "/app/docker-entrypoint.sh" ]
+# Add the SSH tunnel script
+COPY firebird-ssh-tunnel.sh /app/
+RUN ["chmod", "+x", "/app/firebird-ssh-tunnel.sh"]
+
+# Run the SSH tunnel and Metabase
+ENTRYPOINT ["/bin/bash", "-c", "/app/firebird-ssh-tunnel.sh & /app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,4 +34,6 @@ fi
 echo "JAVA_OPTS: $JAVA_OPTS"
 export JAVA_OPTS
 
+/app/firebird-ssh-tunnel.sh &
+
 /app/run_metabase.sh

--- a/firebird-ssh-tunnel.sh
+++ b/firebird-ssh-tunnel.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script is necessary because the Metabase driver for Firebird does not support SSH tunneling.
+# Therefore, we need this script to establish and maintain an SSH tunnel manually.
+# The SSH tunnel forwards a local port to a remote port on the Firebird server,
+# enabling secure communication between Metabase and the Firebird database over SSH.
+# The script includes a loop to reconnect automatically if the connection is interrupted.
+
+# Define SSH tunnel parameters.
+# ELEPHANT_TEST_REMOTE_USER: The username to use for SSH login.
+# ELEPHANT_TEST_REMOTE_HOST: The remote host to connect to via SSH.
+# ELEPHANT_TEST_LOCAL_PORT: The local port to bind for the SSH tunnel.
+# ELEPHANT_TEST_REMOTE_PORT: The remote port to forward to through the SSH tunnel.
+# ELEPHANT_TEST_REMOTE_PASSWORD: The password for the SSH user.
+
+ELEPHANT_TEST_REMOTE_USER=${ELEPHANT_TEST_REMOTE_USER}
+ELEPHANT_TEST_REMOTE_HOST=${ELEPHANT_TEST_REMOTE_HOST}
+ELEPHANT_TEST_LOCAL_PORT=${ELEPHANT_TEST_LOCAL_PORT}
+ELEPHANT_TEST_REMOTE_PORT=#{ELEPHANT_TEST_REMOTE_PORT}
+ELEPHANT_TEST_REMOTE_PASSWORD=${ELEPHANT_TEST_REMOTE_PASSWORD}
+
+# Function to establish SSH tunnel using sshpass and ssh.
+# This function will create an SSH tunnel that forwards 
+# local port 3050 to the remote port 3050 on the remote host.
+start_tunnel() {
+    sshpass -p ${ELEPHANT_TEST_REMOTE_PASSWORD} ssh -o StrictHostKeyChecking=no -L 127.0.0.1:${ELEPHANT_TEST_LOCAL_PORT}:127.0.0.1:${ELEPHANT_TEST_REMOTE_PORT} ${ELEPHANT_TEST_REMOTE_USER}@${ELEPHANT_TEST_REMOTE_HOST} -N
+}
+
+# Infinite loop to keep the SSH tunnel alive.
+# If the tunnel gets disconnected, it will wait for 5 seconds
+# and then attempt to reconnect.
+while true; do
+    start_tunnel
+    echo "SSH connection interrupted. Reconnecting in 5 seconds..."
+    sleep 5
+done


### PR DESCRIPTION
Ticket: https://www.notion.so/hasomed-tech/Connect-Elefant-DB-to-metabase-65645d9b368148d3b911317364a8c5ae

**Set ENV vars before deploy to production**
```
ELEFANT_TEST_REMOTE_USER: The username to use for SSH login.
ELEFANT_TEST_REMOTE_HOST: The remote host to connect to via SSH.
ELEFANT_TEST_LOCAL_PORT: The local port to bind for the SSH tunnel.
ELEFANT_TEST_REMOTE_PORT: The remote port to forward to through the SSH tunnel.
ELEFANT_TEST_REMOTE_PASSWORD: The password for the SSH user.
```
Downgrade Metabase version to 0.47.13 because it is the highest version that currently works with the Firebird plugin (https://github.com/evosec/metabase-firebird-driver)
